### PR TITLE
Fix keyCharsToKey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fexceptions -std=gnu++17
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= -lnx `freetype-config --libs` -lz
+LIBS	:= -lnx `freetype-config --libs`
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fexceptions -std=gnu++17
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= -lnx `freetype-config --libs`
+LIBS	:= -lnx `freetype-config --libs` -lz
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/source/gui_main.cpp
+++ b/source/gui_main.cpp
@@ -143,8 +143,10 @@ std::string GuiMain::keyToKeyChars(u64 key, bool overrideByDefault) {
 void GuiMain::keyCharsToKey(std::string str, u64 *key, bool *overrideByDefault) {
   *overrideByDefault = (str[0] == '!');
 
-  str = str.substr(1);
-  
+  if (*overrideByDefault) {
+	  str = str.substr(1);
+  }
+
   if (str == "A") *key = KEY_A;
   else if (str == "B") *key = KEY_B;
   else if (str == "X") *key = KEY_X;


### PR DESCRIPTION
keyCharsToKey currently takes the substring of the current key value regardless if '!' is present.

So if your current string is "R" it will change to "" before the function can identify the key.
Resulting in the key not being recognized/displayed in the app on startup.

Additionally if the user then changes the "Open Album by default" to on or off before picking a key, loader will result in values like:
"override_key="
or
"override_key=!"

I re-used *overrideByDefault as the condition since that would have already been set by the time the if is called, though (str[0] == '!') should work the same if you'd rather use that for the condition.