### PR TITLE
Fix typo in gui_sysmodule.cpp

### DIFF
--- a/source/gui_sysmodule.cpp
+++ b/source/gui_sysmodule.cpp
@@ -91,14 +91,14 @@ GuiSysmodule::GuiSysmodule() : Gui() {
           if (!sysmodule.second.requiresReboot) {
             pmshellTerminateProcessByTitleId(tid);
           } else {
-            (new MessageBox("This sysmodule requires a reboot to fully work. \n Please restart your console in order use in.", MessageBox::OKAY))->show();
+            (new MessageBox("This sysmodule requires a reboot to fully work. \n Please restart your console in order use it.", MessageBox::OKAY))->show();
           }
 
           remove(path.str().c_str());
         }
         else {
           if (sysmodule.second.requiresReboot) {
-            (new MessageBox("This sysmodule requires a reboot to fully work. \n Please restart your console in order use in.", MessageBox::OKAY))->show();
+            (new MessageBox("This sysmodule requires a reboot to fully work. \n Please restart your console in order use it.", MessageBox::OKAY))->show();
             FILE *fptr = fopen(path.str().c_str(), "wb+");
             if (fptr != nullptr) fclose(fptr);
           } else {


### PR DESCRIPTION
Changed `to use in` to `to use it` in sysmodule enabled message.