### PR TITLE
Enable ccache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,8 @@ ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=$(DEVKITPRO)/libnx/switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
 LIBS	:= -lnx `freetype-config --libs`
+CXX		:= `which ccache` $(CXX)
+CC		:= `which ccache` $(CC)
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing


### PR DESCRIPTION
Enabling ccache makes for faster compiles and causes no issues compiling on machines without ccache setup.  Just merge any anyone with ccache will see it after compiling once.